### PR TITLE
update readme with info on how to connect to the newly created db

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,6 +48,7 @@ Install Postgres and set up the database:
     psql postgres  # Start the Postgres command-line client
     
     CREATE DATABASE "nextjs-pwa-graphql-sql";  -- You can also use \connect to connect to existing database
+    \connect "nextjs-pwa-graphql-sql";
     CREATE TABLE article (id serial, title varchar(200), content text);  -- Create a blank table
     INSERT INTO article (title) VALUES ('The first article');  -- Add example data
     SELECT * FROM article;  -- Check data exists


### PR DESCRIPTION
Hej Tom! :)

It's needed to explicity connect to the db after creating it when using psql. Otherwise when you later create the table it will be created on whatever db you're connected to. In my case this was the default `postgres´ db which gave me very confusing errors later on when the table was not found.